### PR TITLE
Feature - added details summary partial

### DIFF
--- a/views/partials/details-summary.html
+++ b/views/partials/details-summary.html
@@ -1,0 +1,8 @@
+<details>
+  <summary role="button">
+    <span class="summary">{{summary}}</span>
+  </summary>
+  <div class="panel-indent">
+    {{details}}
+  </div>
+</details>


### PR DESCRIPTION
This is used to render a details/summary element expected to be called with a details local (content) and summary local (header/clickable element). Renders details in a panel-indent