### PR TITLE
Add conditional placeholder attribute for a nonce (number used once)

### DIFF
--- a/views/partials/gatag.html
+++ b/views/partials/gatag.html
@@ -1,5 +1,5 @@
 {{#gaTagId}}
-    <script>
+    <script{{#nonce}} nonce="{{nonce}}"{{/nonce}}>
       (function(i,s,o,g,r,a,m){i['GoogleAnalyticsObject']=r;i[r]=i[r]||function(){
       (i[r].q=i[r].q||[]).push(arguments)},i[r].l=1*new Date();a=s.createElement(o),
       m=s.getElementsByTagName(o)[0];a.async=1;a.src=g;m.parentNode.insertBefore(a,m)


### PR DESCRIPTION
Future CSP work will use nonces or hashes to sign inline script tags (https://github.com/alphagov/govuk_template/issues/258). 
This PR adds a nonce attribute to the GA TAG inline script tag 