### PR TITLE
bugfix - post form to self

### DIFF
--- a/views/partials/form.html
+++ b/views/partials/form.html
@@ -1,4 +1,4 @@
-<form action="{{action}}" method="POST" {{$encoding}}{{/encoding}} autocomplete="off" novalidate="true" spellcheck="false">
+<form action="" method="POST" {{$encoding}}{{/encoding}} autocomplete="off" novalidate="true" spellcheck="false">
   {{$form}}{{/form}}
   {{#csrf-token}}
     <input type="hidden" name="x-csrf-token" value="{{csrf-token}}" />


### PR DESCRIPTION
removed `action` from form element so it posts to self preserving query params