### PR TITLE
Expose a method to get aggregated translation resources

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -1,0 +1,5 @@
+extends:
+- "homeoffice/config/default"
+
+env:
+  es6: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,6 @@
+language: node_js
+node_js:
+  - "6"
+  - "4"
+before_install:
+  - if [[ `npm -v` != 3* ]]; then npm i -g npm@3; fi

--- a/README.md
+++ b/README.md
@@ -53,64 +53,23 @@ app.use(function (req, res, next) {
 
 ### Translations
 
-#### Standalone
+The provided translations are designed to be used in conjunction with a translations library such as [i18n-future](https://github.com/lennym/i18n-future).
 
-The provided translations are designed to be used in conjunction with a translations library such as [i18n-future](https://github.com/lennym/i18n-future). The source files are compiled automatically post-install. If you need to re-compile run the following:
+The exported `resources` method will return a compiled object containing the translations, which can be passed to an `i18n` instance as a pre-compiled resource.
 
-```bash
-$ npm run transpile
-```
-
-The compiled translations file can be found at `hof-template-partials/translations/{lang}/default.json.`
-
-To use with i18n-future:
-
-app.js
 ```js
-var i18n = require('i18n-future')({
-  path: require('hof-template-partials').translations
+const translate = require('i18n-future').middleware({
+  resources: require('hof-template-partials').resources()
 });
-
-i18n.on('ready', function () {
-  var lookedup = i18n.translate('key');
-});
+app.use(translate);
 ```
 
-#### HOF Application
+By default the namespace for this translation is `default`. A custom namespace can be specified by passing it as an argument to the `resources` function.
 
-The provided translations can be combined with your application shared and route specific translations by using [hof-transpiler](https://github.com/UKHomeOffice/hof-transpiler). You can run the following script:
-
-```bash
-$ npm install hof-transpiler
-$ ./node_modules/.bin/hof-transpiler path/to/translations/src -w --shared path/to/shared/translations/src --shared node_modules/hof-template-partials/translations/src
-```
-
-or add the following to `scripts` in `package.json`
-```json
-"scripts": {
-  "transpile": "hof-transpiler path/to/translations/src -w --shared path/to/shared/translations/src --shared node_modules/hof-template-partials/translations/src"
-}
-```
-
-and run with:
-
-```bash
-$ npm run transpile
-```
-
-This will extend from right to left so any duplicate keys will be overwritten by the left-most source.
-
-### Rendering Terms & Conditions and Cookies
-
-These templates are scoped to their respective translation files so you would render them in the following way:
-
-app.js
 ```js
-app.get('/terms', function (req, res, next) {
-  i18n.on('ready', function () {
-    // express will look for a terms.html template in the
-    // directories defined earlier
-    res.render('terms', i18n.translate('terms'))
-  });
+const translate = require('i18n-future').middleware({
+  resources: require('hof-template-partials').resources('hof-common'),
+  fallbackNamespace: 'hof-common'
 });
+app.use(translate);
 ```

--- a/index.js
+++ b/index.js
@@ -1,8 +1,9 @@
-'use strict'
+'use strict';
 
 const path = require('path');
 
 module.exports = {
   views: path.resolve(__dirname, './views'),
-  translations: path.resolve(__dirname, './translations/__lng__/__ns__.json')
+  translations: path.resolve(__dirname, './translations/__lng__/__ns__.json'),
+  resources: require('./translations')
 };

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "A collection of Mustache partials and i18n translations to be used in HOF applications",
   "main": "index.js",
   "keywords": [],
+  "scripts": {
+    "test": "eslint ."
+  },
   "author": "UKHomeOffice",
   "contributors": [
     "Joe Fitter <joe@brightapp.io> (http://brightapp.io/)"
@@ -11,5 +14,9 @@
   "license": "GPLv2",
   "dependencies": {
     "lodash": "^4.17.4"
+  },
+  "devDependencies": {
+    "eslint": "^3.16.1",
+    "eslint-config-homeoffice": "^2.1.2"
   }
 }

--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
   ],
   "license": "GPLv2",
   "dependencies": {
-    "hof-transpiler": "0.0.6"
+    "hof-transpiler": "0.0.6",
+    "lodash": "^4.17.4"
   }
 }

--- a/package.json
+++ b/package.json
@@ -3,10 +3,6 @@
   "version": "3.2.0",
   "description": "A collection of Mustache partials and i18n translations to be used in HOF applications",
   "main": "index.js",
-  "scripts": {
-    "transpile": "hof-transpiler ./translations/src -s FIXME",
-    "postinstall": "npm run transpile"
-  },
   "keywords": [],
   "author": "UKHomeOffice",
   "contributors": [
@@ -14,7 +10,6 @@
   ],
   "license": "GPLv2",
   "dependencies": {
-    "hof-transpiler": "0.0.6",
     "lodash": "^4.17.4"
   }
 }

--- a/translations/index.js
+++ b/translations/index.js
@@ -1,0 +1,28 @@
+'use strict';
+
+const path = require('path');
+const fs = require('fs');
+const _ = require('lodash')
+
+const langs = fs.readdirSync(path.resolve(__dirname, 'src'));
+
+const resources = langs.reduce((map, lang) => {
+  map[lang] = { default: {} };
+  const files = fs.readdirSync(path.resolve(__dirname, 'src', lang));
+  files.forEach(file => {
+    if (path.extname(file) === '.json') {
+      const name = path.basename(file, '.json');
+      map[lang].default[name] = require(path.resolve(__dirname, 'src', lang, file));
+    }
+  });
+  return map;
+}, {});
+
+module.exports = (namespace) => {
+  if (typeof namespace === 'string') {
+    return _.mapValues(resources, lang => {
+      return { [namespace]: lang.default };
+    });
+  }
+  return resources;
+};

--- a/translations/index.js
+++ b/translations/index.js
@@ -2,7 +2,7 @@
 
 const path = require('path');
 const fs = require('fs');
-const _ = require('lodash')
+const _ = require('lodash');
 
 const langs = fs.readdirSync(path.resolve(__dirname, 'src'));
 


### PR DESCRIPTION
The most efficient way to getting preset translation resources into i18n-future is by declaring them at initialisation. Add a method to expose the translations from this module as a pre-defined resource.