### PR TITLE
Add startLink to error page template

### DIFF
--- a/views/error.html
+++ b/views/error.html
@@ -4,7 +4,7 @@
   {{/header}}
   {{$content}}
     <p>{{{content.message}}}</p>
-    <a href="/" class="button" role="button">{{#t}}buttons.start-again{{/t}}</a>
+    <a href="/{{startLink}}" class="button" role="button">{{#t}}buttons.start-again{{/t}}</a>
     {{#showStack}}
       <pre>
         {{error.stack}}


### PR DESCRIPTION
This property is set here - https://github.com/UKHomeOfficeForms/hof-middleware/blob/master/lib/errors.js#L55

We should use it, especially for apps that don't serve anything on `/`