### PR TITLE
Move `#content` anchor to appropriate container

### DIFF
--- a/views/layout.html
+++ b/views/layout.html
@@ -8,7 +8,7 @@
   {{$headerClass}}with-proposition{{/headerClass}}
   {{$insideHeader}}{{/insideHeader}}
   {{$main}}
-    <main id="content" class="main" role="main">
+    <main class="main" role="main">
       <div class="phase-banner">
         <p>
           <strong class="phase-tag">{{#t}}journey.phase{{/t}}</strong>
@@ -18,7 +18,7 @@
       <span id="step">
         {{> partials-back}} <span>{{$step}}{{/step}}</span>
       </span>
-      <div class="grid-row">
+      <div class="grid-row" id="content">
         {{> partials-maincontent-left}}
       </div>
       {{> partials-gatag}}


### PR DESCRIPTION
It's been raised in accessibility testing that the "skip to main content" link (included in the govuk template) does not link to the appropriate location, and leaves the user to still naviate past non-content links.