### PR TITLE
Unescape page titles

### DIFF
--- a/views/partials/page.html
+++ b/views/partials/page.html
@@ -11,7 +11,7 @@
     {{> partials-navigation}}
   {{/propositionHeader}}
 
-  {{$header}}{{title}}{{/header}}
+  {{$header}}{{{title}}}{{/header}}
   {{$content}}
     {{<partials-form}}
       {{$form}}


### PR DESCRIPTION
Where a page title already contains templated content - e.g. inserting user input from previous steps - then the values are already escaped, and so should not be escaped again, as this results in raw html entities being output to the page - e.g. `&#39;` instead of a single-quote/apostrophe.

Remove the escaping here since the title is rendered from a templated value, which is already therefore escaped.

## Before:

<img width="840" alt="screen shot 2017-05-12 at 12 06 59" src="https://cloud.githubusercontent.com/assets/117398/25995716/96ca191e-370b-11e7-972b-8fd3c4f8356a.png">

## After:

<img width="609" alt="screen shot 2017-05-12 at 12 04 32" src="https://cloud.githubusercontent.com/assets/117398/25995720/9e3badac-370b-11e7-8397-4b0e1e59b2ff.png">

## A slightly better "after" without the XSS check:

<img width="521" alt="screen shot 2017-05-12 at 12 13 27" src="https://cloud.githubusercontent.com/assets/117398/25995928/7e6e7c42-370c-11e7-91be-88a33eb6ebaf.png">
