### PR TITLE
Remove hard-coded GRO query string token

### DIFF
--- a/views/layout.html
+++ b/views/layout.html
@@ -12,7 +12,7 @@
       <div class="phase-banner">
         <p>
           <strong class="phase-tag">{{#t}}journey.phase{{/t}}</strong>
-          <span>This is a new service – your <a href="https://eforms.homeoffice.gov.uk/outreach/feedback.ofml?FormName=GRO_Beta_Feedback">feedback</a> will help us to improve it.</span>
+          <span>This is a new service – your <a href="https://eforms.homeoffice.gov.uk/outreach/feedback.ofml">feedback</a> will help us to improve it.</span>
         </p>
       </div>
       <span id="step">


### PR DESCRIPTION
@gxxm tells me this gets handled automatically by referrer headers now. Even if it doesn't, it certainly shouldn't be hard-coded to GRO.