### PR TITLE
Add `intro` section placeholder to page template

### DIFF
--- a/views/partials/page.html
+++ b/views/partials/page.html
@@ -15,7 +15,9 @@
   {{$content}}
     {{<partials-form}}
       {{$form}}
-        {{#intro}}<p class="form-block">{{intro}}</p>{{/intro}}
+        {{$intro}}
+          {{#intro}}<p class="form-block">{{intro}}</p>{{/intro}}
+        {{/intro}}
         {{$page-content}}{{/page-content}}
       {{/form}}
     {{/partials-form}}


### PR DESCRIPTION
This allows pages to define a more complex intro section than a single paragraph of text if required by defining a section placeholder that can be overridden in page templates if required.

## Example

```
{{<step}}
  {{$intro}}
    {{#markdown}}my-markdown-content{{/markdown}}
  {{/intro}}
{{/step}}
```