### PR TITLE
Fix inheritance for `intro` section

### DIFF
--- a/views/partials/form.html
+++ b/views/partials/form.html
@@ -1,4 +1,7 @@
 <form action="" method="POST" {{$encoding}}{{/encoding}} autocomplete="off" novalidate="true" spellcheck="false">
+  {{$intro}}
+    {{#intro}}<p class="form-block">{{intro}}</p>{{/intro}}
+  {{/intro}}
   {{$form}}{{/form}}
   {{#csrf-token}}
     <input type="hidden" name="x-csrf-token" value="{{csrf-token}}" />

--- a/views/partials/page.html
+++ b/views/partials/page.html
@@ -15,9 +15,6 @@
   {{$content}}
     {{<partials-form}}
       {{$form}}
-        {{$intro}}
-          {{#intro}}<p class="form-block">{{intro}}</p>{{/intro}}
-        {{/intro}}
         {{$page-content}}{{/page-content}}
       {{/form}}
     {{/partials-form}}


### PR DESCRIPTION
It looks like there are restrictions on where a template section variable can be defined, that I'm not fully certain I understand. However, previously with the intro section defined where it was, the intro was not rendered unless it was specified in an implementing template (i.e. not falling back to translated intro). By moving the defaulting of the intro section up a level in the template hierarchy it is rendered correctly in all cases.