### PR TITLE
Add navigation element to proposition header

### DIFF
--- a/views/partials/navigation.html
+++ b/views/partials/navigation.html
@@ -1,5 +1,7 @@
 <div class="header-proposition">
   <div class="content">
-    <a href="{{baseUrl}}" id="proposition-name">{{$journeyHeader}}{{/journeyHeader}}</a>
+    <nav id="proposition-menu">
+      <a href="{{baseUrl}}" id="proposition-name">{{$journeyHeader}}{{/journeyHeader}}</a>
+    </nav>
   </div>
 </div>


### PR DESCRIPTION
This commit adds a nav#propsition-menu around the proposition name
in the GOV.UK header, as copied from the prototype kit.

Previously, the headings were slightly off-centre:
![current](https://user-images.githubusercontent.com/817054/27437082-1a0e1e0c-5759-11e7-8cae-2776ddcef461.png)

This commit adds a `<nav>` copied from the GOV.UK prototype kit to make it line up with the logo again:
![fixed](https://user-images.githubusercontent.com/817054/27437130-36463622-5759-11e7-8c86-1757fa1cd403.png)
