### PR TITLE
Fix- Error template remove `/` from startlink, it'll be passed in by locals from hof-middleware

### DIFF
--- a/views/session-timeout.html
+++ b/views/session-timeout.html
@@ -1,6 +1,6 @@
 {{<error}}
   {{$content}}
     <p>{{{content.message}}}</p>
-    <a href="/{{startLink}}" class="button" role="button">{{#t}}buttons.start-again{{/t}}</a>
+    <a href="{{startLink}}" class="button" role="button">{{#t}}buttons.start-again{{/t}}</a>
   {{/content}}
 {{/error}}


### PR DESCRIPTION
This is to fix the issue when an app does not have a baseUrl e.g. like right to rent.  Previously, if you clicked on the start again button for an error page you would not be sent back to the start page.

This is dependent on hof-middleware PR to be merged https://github.com/UKHomeOfficeForms/hof-middleware/pull/30