### PR TITLE
Fix before install script to not downgrade npm

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -5,4 +5,4 @@ node_js:
   - '7'
   - '8'
 before_install:
-  - 'if [[ `npm -v` != 3* ]]; then npm i -g npm@3; fi'
+  - 'if [[ `npm -v` == 2* ]]; then npm i -g npm@5; fi'


### PR DESCRIPTION
Only npm@2 causes issues, so don't downgrade npm@4 or npm@5

This should be done on all repos eventually, but I'm starting with the ones where npm@3 is causing issues with node@9.