### PR TITLE
Add some Welsh translations

### DIFF
--- a/translations/src/cy/base.json
+++ b/translations/src/cy/base.json
@@ -1,0 +1,4 @@
+{
+  "terms": "Telerau ac amodau",
+  "cookies": "Cwcis"
+}

--- a/translations/src/cy/buttons.json
+++ b/translations/src/cy/buttons.json
@@ -1,0 +1,6 @@
+{
+  "continue": "Parhau",
+  "change": "Newid",
+  "start-again": "Ddechrau eto",
+  "back": "Yn ôl"
+}

--- a/translations/src/cy/cookies.json
+++ b/translations/src/cy/cookies.json
@@ -1,0 +1,105 @@
+{
+  "banner": {
+    "message": "Mae GOV.UK yn defnyddio cwcis i wneud y safle’n symlach",
+    "link": "Darganfyddwch fwy am gwcis"
+  },
+  "header": "Cwcis",
+  "intro": "Mae’r gwasanaeth hwn yn gosod ffeiliau bychan (a elwir yn ‘cwcis’) ar eich cyfrifiadur er mwyn:",
+  "intro-list": {
+    "items": [
+      "cofio pa negeseuon rydych wedi’u gweld fel nad ydynt yn cael eu dangos i chi eto",
+      "deall sut rydych yn defnyddio’r gwasanaeth er mwyn i ni allu ei ddiweddaru a’i wella",
+      "storio gwybodaeth rydych yn ei roi dros dro i gefnogi eich cais"
+    ]
+  },
+  "indent-intro": {
+    "content": "Nid yw’r cwcis a ddefnyddiwn yn eich adnabod yn bersonol."
+  },
+  "cookies-link": {
+    "before": "Darganfyddwch ",
+    "href": "http://www.aboutcookies.org/Default.aspx?page=1",
+    "link": "sut i reoli cwcis"
+  },
+  "intro-cookie": "Neges cyflwyno cwcis",
+  "intro-cookie-message": "Pan fyddwch yn defnyddio’r gwasanaeth am y tro cyntaf rydym yn dangos ‘neges cwcis’. Yna rydym yn storio cwci ar eich cyfrifiadur fel nad yw’n dangos y neges yma i chi eto.",
+  "intro-cookie-table": {
+    "headers": [
+      "Enw",
+      "Pwrpas",
+      "Dod i ben"
+    ],
+    "rows": [
+      [
+        "seen_cookie_message",
+        "Yn gadael i ni wybod eich bod wedi gweld ein neges cwcis yn barod",
+        "1 mis"
+      ]
+    ]
+  },
+  "measuring-use": "Mesur defnydd o’r safle",
+  "google-analytics": [
+    "Rydym yn defnyddio Google Analytics i gasglu gwybodaeth am sut rydych chi’n defnyddio\nr gwasanaeth hwn. Mae hyn yn ein helpu i wirio ei fod yn diwallu eich anghenion ac i wneud gwelliannau.",
+    "Mae Google Analytics yn storio gwybodaeth am:"
+  ],
+  "google-analytics-list": {
+    "items": [
+      "sut wnaethoch chi gyrraedd y safle",
+      "tudalennau rydych yn ymweld â hwy a faint o amser rydych yn ei dreulio arnynt",
+      "beth rydych yn clicio arno"
+    ]
+  },
+  "no-identify": "Nid oes unrhyw fanylion personol yn cael eu storio gyda’r wybodaeth hon, felly ni ellir eich adnabod.",
+  "analytics-table": {
+    "headers": [
+      "Enw",
+      "Pwrpas",
+      "Dod i ben"
+    ],
+    "rows": [
+      [
+        "_ga",
+        "Defnyddir i wahaniaethu defnyddwyr",
+        "2 flynedd"
+      ],
+      [
+        "_gat",
+        "Defnyddir i wasgu’r gyfradd ceisiadau",
+        "10 munud"
+      ]
+    ]
+  },
+  "indent-ga": {
+    "content": "Ni chaniateir i Google ddefnyddio neu rannu ein data dadansoddol."
+  },
+  "opt-out-link": {
+    "before": "Gallwch ",
+    "href": "https://tools.google.com/dlpage/gaoptout",
+    "link": "eithrio allan o Google Analytics "
+  },
+  "session-cookies": "Cwcis sesiwn",
+  "session-cookies-content": "Mae cwcis sesiwn yn cael eu lawrlwytho bob tro y byddwch yn ymweld â\nr gwasanaeth ac yn cael eu dileu pan fyddwch yn cau eich porwr. Maent yn helpu’r gwasanaeth i weithio’n iawn.",
+  "session-cookies-table": {
+    "headers": [
+      "Enw",
+      "Pwrpas",
+      "Dod i ben"
+    ],
+    "rows": [
+      [
+        "hmbrp.sid",
+        "Mae’n Storio ID sesiwn a storio data rydych chi\nn ei gofnodi dros dro i’ch galluogi i wneud cais",
+        "Pan fyddwch yn cau eich porwr"
+      ],
+      [
+        "hof-wizard-sc",
+        "Mae’n dweud wrthym pan mae eich sesiwn yn dechrau fel ein bod yn gallu dweud wrthych os yw’n dod i ben",
+        "Pan fyddwch yn cau eich porwr"
+      ],
+      [
+        "hof-cookie-check",
+        "Mae’n dweud wrthym eich bod wedi galluogi cwcis yn barod fel nad oes angen i ni ofyn i chi eto",
+        "Pan fyddwch yn cau eich porwr"
+      ]
+    ]
+  }
+}

--- a/translations/src/cy/errorlist.json
+++ b/translations/src/cy/errorlist.json
@@ -1,0 +1,6 @@
+{
+  "title": {
+    "single": "Dylech gywiro’r gwallau canlynol",
+    "multiple": "Dylech gywiro’r gwallau canlynol"
+  }
+}

--- a/translations/src/cy/errors.json
+++ b/translations/src/cy/errors.json
@@ -1,0 +1,18 @@
+{
+  "default": {
+    "title": "Mae’n ddrwg gennym, mae rhywbeth wedi mynd o’i le",
+    "message": "Digwyddodd eithriad serfiwr. Rhowch gynnig arall."
+  },
+  "session": {
+    "title": "Mae’n ddrwg gennym, mae rhywbeth wedi mynd o’i le",
+    "message": "Nid ydych wedi rhoi unrhyw fanylion am 30 munud, felly rydym wedi clirio eich gwybodaeth i’w gadw’n ddiogel."
+  },
+  "404": {
+    "title": "Ni ddaethpwyd o hyd i dudalen",
+    "description": "Nid yw’r dudalen hon yn bodoli"
+  },
+  "cookies-required": {
+    "title": "Mae angen cwcis i ddefnyddio’r gwasanaeth hwn",
+    "message": "Mae angen cwcis er mwyn ddefnyddio’r gwasanaeth hwn .<br /><br /> Dylech <a href=\"http://www.aboutcookies.org/how-to-control-cookies/\" rel=\"external\">alluogi cwcis</a> and try again. Find out <a href=\"/cookies\">sut rydym yn defnyddio cwcis</a>."
+  }
+}

--- a/translations/src/cy/terms.json
+++ b/translations/src/cy/terms.json
@@ -1,0 +1,28 @@
+{
+  "header": "Telerau ac amodau",
+  "how-we-use": "Sut rydym yn defnyddio eich gwybodaeth",
+  "data-link": {
+    "before": "Mae’r data rydych yn ei ddarparu yn cael ei ddefnyddio yn unol â ",
+    "href": "https://www.gov.uk/government/organisations/home-office/about/personal-information-charter",
+    "link": "siarter gwybodaeth y Swyddfa Gartref",
+    "after": ". Mae hyn yn cynnwys gwybodaeth am yr ymgeisydd ac unrhyw berson sy’n noddi eu cais. Y Swyddfa Gartref yw’r rheolydd data, sy’n golygu ei fod yn penderfynu sut y caiff y wybodaeth hon ei defnyddio a’i storio. Bydd y wybodaeth yn cael ei chadw’n gyfrinachol a’i thrin yn unol â Deddf Diogelu Data 1998."
+  },
+  "used-for": "Bydd y wybodaeth yn cael ei ddefnyddio i:",
+  "used-for-list": {
+    "items": [
+      "wneud penderfyniad ar gais",
+      "atal a chanfod troseddau"
+    ]
+  },
+  "your-info": "Gall eich gwybodaeth gael ei throsglwyddo i drydydd partïon, adrannau’r llywodraeth, awdurdodau lleol, llywodraethau tramor a chyrff cyhoeddus at ddibenion:",
+  "your-info-list": {
+    "items": [
+      "cadarnhau bod y wybodaeth a roddwyd gennych yn gywir,",
+      "atal a chanfod troseddau, gan gynnwys twyll a gwyngalchu arian",
+      "caniatáu i drydydd parti, adran o’r llywodraeth, awdurdod lleol neu gorff cyhoeddus gynnal eu hyfforddiant staff"
+    ]
+  },
+  "info-gathered": "Mae’r Swyddfa Gartref yn cadw’r hawl i gasglu gwybodaeth sy’n ymwneud â defnyddio’r safle. Mae unrhyw wybodaeth a gesglir ar gyfer defnydd mewnol yn bennaf, er enghraifft, i wella gwasanaeth cwsmeriaid.",
+  "countries": "Cyfeiriadau at wledydd a chenhedloedd",
+  "countries-text": "Gellir rhestru gwlad neu diriogaeth fel cenedligrwydd neu wlad oherwydd bod ganddi awdurdod i roi pasbort."
+}


### PR DESCRIPTION
This commit adds some Welsh translations from our downstream project.
The list is only partial, as some strings do not occur in our project so
were not translated, or were sufficiently divorced from their original
meaning that to copy them across to this project would be inappropriate.

However, it does include the two legal boilerplate pages, which will
likely be useful for any subsequent projects using this codebase.

These messages were translated by the Department of Work and Pensions on
behalf of the Home Office.