### PR TITLE
Issue 166: Move error summary to the top

### DIFF
--- a/views/partials/maincontent-left.html
+++ b/views/partials/maincontent-left.html
@@ -1,10 +1,10 @@
 {{$content-outer}}
 {{$preloader}}{{/preloader}}
   <div class="column-two-thirds">
+    {{$validationSummary}}{{/validationSummary}}
     <header>
       <h1>{{$header}}{{/header}}</h1>
     </header>
-    {{$validationSummary}}{{/validationSummary}}
     {{$content}}{{/content}}
   </div>
 {{/content-outer}}


### PR DESCRIPTION
As GDS guidelines move error summary to the top
https://github.com/UKHomeOfficeForms/hof/issues/167