### PR TITLE
Add "Error: " prefix to page title

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hof-template-partials",
-  "version": "4.0.1",
+  "version": "4.1.0",
   "description": "A collection of Mustache partials and i18n translations to be used in HOF applications",
   "main": "index.js",
   "keywords": [],

--- a/translations/src/en/errorlist.json
+++ b/translations/src/en/errorlist.json
@@ -1,4 +1,5 @@
 {
+  "prefix": "Error: ",
   "title": {
     "single": "Please fix the following error",
     "multiple": "Please fix the following errors"

--- a/views/layout.html
+++ b/views/layout.html
@@ -3,7 +3,7 @@
     {{> partials-head}}
   {{/head}}
   {{$pageTitle}}
-    {{#errorlist.length}}Error: {{/errorlist.length}}{{$header}}{{/header}} &ndash; GOV.UK
+    {{#errorlist.length}}{{#t}}errorlist.prefix{{/t}}{{/errorlist.length}}{{$header}}{{/header}} &ndash; GOV.UK
   {{/pageTitle}}
   {{$headerClass}}with-proposition{{/headerClass}}
   {{$insideHeader}}{{/insideHeader}}

--- a/views/layout.html
+++ b/views/layout.html
@@ -3,7 +3,7 @@
     {{> partials-head}}
   {{/head}}
   {{$pageTitle}}
-    {{$header}}{{/header}} &ndash; GOV.UK
+    {{#errorlist.length}}Error: {{/errorlist.length}}{{$header}}{{/header}} &ndash; GOV.UK
   {{/pageTitle}}
   {{$headerClass}}with-proposition{{/headerClass}}
   {{$insideHeader}}{{/insideHeader}}


### PR DESCRIPTION
...when the page contains validation errors (as per GDS design guidelines).