### PR TITLE
Allow footerSupportLinks to be specified

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hof-template-partials",
-  "version": "4.4.0",
+  "version": "4.5.0",
   "description": "A collection of Mustache partials and i18n translations to be used in HOF applications",
   "main": "index.js",
   "keywords": [],

--- a/views/layout.html
+++ b/views/layout.html
@@ -33,8 +33,13 @@
   {{/cookieMessage}}
   {{$footerSupportLinks}}
     <ul>
-      <li><a href="/cookies">{{#t}}base.cookies{{/t}}</a></li>
-      <li><a href="/terms-and-conditions">{{#t}}base.terms{{/t}}</a></li>
+      {{#footerSupportLinks}}
+        <li><a href="{{path}}">{{#t}}{{property}}{{/t}}</a></li>
+      {{/footerSupportLinks}}
+      {{^footerSupportLinks}}
+        <li><a href="/cookies">{{#t}}base.cookies{{/t}}</a></li>
+        <li><a href="/terms-and-conditions">{{#t}}base.terms{{/t}}</a></li>
+      {{/footerSupportLinks}}
     </ul>
   {{/footerSupportLinks}}
 {{/govuk-template}}


### PR DESCRIPTION
As part of app config. E.G.:

res.locals.footerSupportLinks = [
  { path: '/cookies', property: 'base.cookies' },
  { path: '/terms-and-conditions', property: 'base.terms' },
  { path: '/accessibility', property: 'base.accessibility' },
];