### PR TITLE
fix: correct heading level for summary page section

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hof-template-partials",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hof-template-partials",
-  "version": "5.0.0",
+  "version": "5.0.1",
   "description": "A collection of Mustache partials and i18n translations to be used in HOF applications",
   "main": "index.js",
   "keywords": [],

--- a/views/partials/summary-table.html
+++ b/views/partials/summary-table.html
@@ -1,4 +1,4 @@
-<h3>{{section}}</h3>
+<h2 class="heading-small">{{section}}</h2>
 <table class="table-details">
   <tbody>
     {{#fields}}


### PR DESCRIPTION
## What
Fixes heading level in summary table partial
## Why
So that heading levels flow correctly from h1 -> h2 etc... for proper functionality with assistive technology
## How
Changes h3 tag to h2 in summary table partial, applies 'heading-small' class to retain the original visual look