### PR TITLE
SD-90: Fix: update validation summary partial to focus on element rather than group

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hof-template-partials",
-  "version": "5.0.1",
+  "version": "5.2.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hof-template-partials",
-  "version": "5.2.1",
+  "version": "5.2.2",
   "description": "A collection of Mustache partials and i18n translations to be used in HOF applications",
   "main": "index.js",
   "keywords": [],

--- a/views/partials/validation-summary.html
+++ b/views/partials/validation-summary.html
@@ -15,7 +15,7 @@
         {{$validation-list}}
             {{#errorlist}}
                 {{#message}}
-                  <li><a href="#{{key}}-group">{{ message }}</a></li>
+                  <li><a href="#{{key}}">{{ message }}</a></li>
                 {{/message}}
             {{/errorlist}}
         {{/validation-list}}


### PR DESCRIPTION
### What
Updates validation summary partial so that summary list items link to the form input where the validation error, rather than the form input's containing group.
### Why
So that the input is correctly focussed when the link is clicked/used.
### How
Update summary partial href to link to the input by id rather than its group.