### PR TITLE
Sd 336 update cookie banner content

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hof-template-partials",
-  "version": "5.3.1",
+  "version": "5.3.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hof-template-partials",
-  "version": "5.3.1",
+  "version": "5.3.2",
   "description": "A collection of Mustache partials and i18n translations to be used in HOF applications",
   "main": "index.js",
   "keywords": [],

--- a/views/partials/cookie-banner.html
+++ b/views/partials/cookie-banner.html
@@ -1,18 +1,21 @@
 <div id="cookie-banner" class="grid-row">
   <div id="cookie-banner-info" class="column-two-thirds">
-    <h1 class="heading-medium js-enabled">Can we store analytics cookies on your device?</h1>
-    <p class="js-enabled">Analytics cookies help us understand how our website is being used.</p>
+    <h1 class="heading-medium js-enabled">Cookies on GOV.UK</h1>
+    <p class="js-enabled">We use some essential cookies to make this website work.</p>
+    <p class="js-enabled">We'd like to set additional cookies to understand how you use GOV.UK, remember your settings and improve government services.</p>
+    <p class="js-enabled">We also use cookies set by other sites to help us deliver content from their services.</p>
     <!--Non-javascript fallback content-->
     <h1 class="heading-medium js-disabled">Tell us whether you accept cookies</h1>
     <p class="js-disabled">
-      We use cookies to collect information about how you use this service.
-      We use this information to make the website work as well as possible and improve government services.
+    We use some essential cookies to make this website work.
+    We'd like to set additional cookies to understand how you use GOV.UK, remember your settings and improve government services.
+    We also use cookies set by other sites to help us deliver content from their services.
     </p>
   </div>
   <div id="cookie-banner-actions" class="column-two-thirds">
-    <button id="accept-cookies-button" class="button js-enabled" type="button" aria-label="Yes, accept cookies that measure website usage">Yes</button>
-    <button id="reject-cookies-button" class="button js-enabled" type="button" aria-label="No, decline cookies that measure website usage">No</button>
-    <a href="/cookies" class="js-enabled">How we use cookies</a>
+    <button id="accept-cookies-button" class="button js-enabled" type="button" aria-label="Yes, accept cookies that measure website usage">Accept additional cookies</button>
+    <button id="reject-cookies-button" class="button js-enabled" type="button" aria-label="No, decline cookies that measure website usage">Reject additional cookies</button>
+    <a href="/cookies" class="js-enabled">View cookies</a>
     <!--Non-javascript fallback content-->
     <a href="/cookies" role="button" class="button js-disabled">Set cookie preferences</a>
   </div>


### PR DESCRIPTION
# What 
An update to the cookie banner content

# Why 
To be more inline with the content used in cookie banners across GOV.UK

# How
Updated content of cookie-banner.html to reflect wording used in GOV.UK cookie banners

# Testing
Tested locally but no additional tests written as this is just a content change