### PR TITLE
SD-642 Updated cookies.json to include gid google analytics cookie

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hof-template-partials",
-  "version": "5.3.2",
+  "version": "5.3.3",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hof-template-partials",
-  "version": "5.3.2",
+  "version": "5.3.3",
   "description": "A collection of Mustache partials and i18n translations to be used in HOF applications",
   "main": "index.js",
   "keywords": [],

--- a/translations/src/en/cookies.json
+++ b/translations/src/en/cookies.json
@@ -71,11 +71,16 @@
         "_gat",
         "Used to throttle request rate",
         "10 minutes"
+      ],
+      [
+        "_gid",
+        "Used to count and track page views",
+        "24 hours"
       ]
     ]
   },
   "indent-ga": {
-    "content": "Google isn’t allowed to use or share our analytics data."
+    "content": "We do not allow Google to use or share the data about how you use this site."
   },
   "session-cookies": "Session cookies",
   "session-cookies-content": "Session cookies are downloaded each time you visit the service and deleted when you close your browser. They help the service to work properly.",


### PR DESCRIPTION
# What
An update to the google analytics part of the cookies page to properly reflect the cookies used in our services

# Why
The table was missing the "_gid" tracking cookie 

# How 
-Added gid cookie in cookies.json
-Update content to align with gov-uk cookies page