### PR TITLE
SD-709 seen_cookie_message is not mentioned in cookie policy

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hof-template-partials",
-  "version": "5.3.3",
+  "version": "5.3.4",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hof-template-partials",
-  "version": "5.3.3",
+  "version": "5.3.4",
   "description": "A collection of Mustache partials and i18n translations to be used in HOF applications",
   "main": "index.js",
   "keywords": [],

--- a/views/cookies.html
+++ b/views/cookies.html
@@ -41,6 +41,11 @@
         {{#indent-intro}}
           {{> partials-panel-indent}}
         {{/indent-intro}}
+        <h2>{{intro-cookie}}</h2>
+        <p>{{intro-cookie-message}}</p>
+        {{#intro-cookie-table}}
+          {{> partials-table}}
+        {{/intro-cookie-table}}
         <div class="js-enabled">
           <h2>{{session-cookies}}</h2>
           <p>{{session-cookies-content}}</p>


### PR DESCRIPTION
# What
An update so that the seen_cookie_message cookie is display correctley in the cookie policy
# Why
the seen_cookie_message cookie message is not displayed in the cookie policy when the user has a ga_tag
# How 
Update to cookies.html to include the intro-cookies-message so that the seen_cookie_message is displayed whether the user has a ga_tag set or not
bumped version number of package
