### PR TITLE
SD-743 Cookie banner needs to reflect service and not GOV.uk

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,3 +73,10 @@ const translate = require('i18n-future').middleware({
 });
 app.use(translate);
 ```
+### Cookie Banner
+
+The cookie banner has a placeholder named serviceName that you can set within the locals of your hof application so that the appropriate value is displayed.
+
+```js
+res.locals.serviceName = <yourServiceName> 
+```

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "hof-template-partials",
-  "version": "5.3.5",
+  "version": "5.4.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "hof-template-partials",
-  "version": "5.3.5",
+  "version": "5.4.0",
   "description": "A collection of Mustache partials and i18n translations to be used in HOF applications",
   "main": "index.js",
   "keywords": [],

--- a/views/partials/cookie-banner.html
+++ b/views/partials/cookie-banner.html
@@ -1,8 +1,8 @@
 <div id="cookie-banner" class="grid-row">
   <div id="cookie-banner-info" class="column-two-thirds">
-    <h1 class="heading-medium js-enabled">Cookies on GOV.UK</h1>
+    <h1 class="heading-medium js-enabled">Cookies on {{serviceName}}</h1>
     <p class="js-enabled">We use some essential cookies to make this website work.</p>
-    <p class="js-enabled">We'd like to set additional cookies to understand how you use GOV.UK, remember your settings and improve government services.</p>
+    <p class="js-enabled">We'd like to set additional cookies to understand how you use this service, remember your settings and improve government services.</p>
     <p class="js-enabled">We also use cookies set by other sites to help us deliver content from their services.</p>
     <!--Non-javascript fallback content-->
     <h1 class="heading-medium js-disabled">Tell us whether you accept cookies</h1>


### PR DESCRIPTION
# What
An update so that the service name can easily be used in the cookie banner instead of GOV.UK

# Why
To show that the cookie policy is relevant to the service and not all gov.uk services

# How 
Modified cookie-banner.html to accept a serviceName variable that allows the service to set its own service name to display in the cookie banner

- Bumped minor version
