### PR TITLE
Add git actions automate npm publishing

### DIFF
--- a/.github/workflows/automate-publish.yml
+++ b/.github/workflows/automate-publish.yml
@@ -1,0 +1,36 @@
+# This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
+# For more information see: https://help.github.com/actions/language-and-framework-guides/publishing-nodejs-packages
+name: Automate_Publish
+on:
+  workflow_run:
+    workflows: ["Automate_Tag"]
+    types:
+      - completed
+jobs:
+  auto-publish:
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/heads/master')
+    steps:
+      - uses: actions/checkout@v2.2.0
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 14
+          registry-url: https://registry.npmjs.org/
+      - name: 'Get Previous tag'
+        id: previoustag
+        uses: "WyriHaximus/github-action-get-previous-tag@v1"
+      - run: npm ci
+      - run: |
+          npm_tag="v$(npm dist-tags | sed -n 's/^.* \([0-9].[0-9].[0-9]\)$/\1/p')"
+          git_tag="$(git describe --abbrev=0)"
+          if [ "$npm_tag" != "$git_tag" ] ; then npm publish; fi
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.npm_bot_token }}
+      - name: 'Publish Release'
+        uses: Roang-zero1/github-create-release-action@master
+        with:
+          created_tag: ${{ steps.previoustag.outputs.tag }}
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/automate-publish.yml
+++ b/.github/workflows/automate-publish.yml
@@ -23,8 +23,8 @@ jobs:
         uses: "WyriHaximus/github-action-get-previous-tag@v1"
       - run: npm ci
       - run: |
-          npm_tag="v$(npm dist-tags | sed -n 's/^.* \([0-9].[0-9].[0-9]\)$/\1/p')"
-          git_tag="$(git describe --abbrev=0)"
+          npm_tag="v$(npm dist-tags | cut -d' ' -f 2)"
+          git_tag="$(git describe --tags | cut -d'-' -f 1)"
           if [ "$npm_tag" != "$git_tag" ] ; then npm publish; fi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.npm_bot_token }}

--- a/.github/workflows/automate-tag.yml
+++ b/.github/workflows/automate-tag.yml
@@ -1,0 +1,76 @@
+# This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
+# For more information see: https://help.github.com/actions/language-and-framework-guides/publishing-nodejs-packages
+name: Automate_Tag
+on: [push]
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [10.x, 12.x, 14.x]
+        redis-version: [4, 5, 6]
+    steps:
+      - uses: actions/checkout@v2.2.0
+      - uses: actions/setup-node@v1
+        with:
+          node-version: ${{ matrix.node-version }}
+      - name: Start Redis
+        uses: supercharge/redis-github-action@1.2.0
+        with:
+          redis-version: ${{ matrix.redis-version }}
+      - run: npm ci
+      - run: npm test
+
+  auto-tag-patch:
+    needs: test
+    runs-on: ubuntu-latest
+    if: |
+      startsWith(github.ref, 'refs/heads/master') &&
+      !contains(github.event.head_commit.message, '[MAJOR]') &&
+      !contains(github.event.head_commit.message, '[MINOR]')
+    steps:
+      - uses: actions/checkout@v2.2.0
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 14
+          registry-url: https://registry.npmjs.org/
+      - run: |
+          git config --local user.email "$(git log --format='%ae' HEAD^!)"
+          git config --local user.name "$(git log --format='%an' HEAD^!)"
+          npm version patch
+
+  auto-tag-minor:
+    needs: test
+    runs-on: ubuntu-latest
+    if: |
+      startsWith(github.ref, 'refs/heads/master') &&
+      !contains(github.event.head_commit.message, '[MAJOR]') &&
+      contains(github.event.head_commit.message, '[MINOR]')
+    steps:
+      - uses: actions/checkout@v2.2.0
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 14
+          registry-url: https://registry.npmjs.org/
+      - run: |
+          git config --local user.email "$(git log --format='%ae' HEAD^!)"
+          git config --local user.name "$(git log --format='%an' HEAD^!)"
+          npm version minor
+
+  auto-tag-major:
+    needs: test
+    runs-on: ubuntu-latest
+    if: |
+      startsWith(github.ref, 'refs/heads/master') &&
+      contains(github.event.head_commit.message, '[MAJOR]') &&
+      !contains(github.event.head_commit.message, '[MINOR]')
+    steps:
+      - uses: actions/checkout@v2.2.0
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 14
+          registry-url: https://registry.npmjs.org/
+      - run: |
+          git config --local user.email "$(git log --format='%ae' HEAD^!)"
+          git config --local user.name "$(git log --format='%an' HEAD^!)"
+          npm version major

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
   "main": "index.js",
   "keywords": [],
   "scripts": {
-    "test": "eslint ."
+    "test": "eslint .",
+    "postversion": "git push && git push --tags"
   },
   "author": "UKHomeOffice",
   "contributors": [


### PR DESCRIPTION
**What**
Adding git actions to automate npm publishing and carry out node tests

**Why**
To automate the npm release process when minor, major or patch changes are made. 

**How**
Copied Git actions from how-form-controller 